### PR TITLE
Use _aligned_malloc for all MSVC-compatible compilers

### DIFF
--- a/include/boost/align/aligned_alloc.hpp
+++ b/include/boost/align/aligned_alloc.hpp
@@ -29,7 +29,7 @@
 #include <AvailabilityMacros.h>
 #endif
 
-#if defined(BOOST_MSVC)
+#if defined(_MSC_VER)
 #include <boost/align/detail/aligned_alloc_msvc.hpp>
 #elif defined(__MINGW32__) && (__MSVCRT_VERSION__ >= 0x0700)
 #include <boost/align/detail/aligned_alloc_msvc.hpp>


### PR DESCRIPTION
Any compiler pretending to be MSVC should implement _aligned_malloc/_aligned_free. In particular this includes Intel Compiler on Windows and (in the future) Clang. These compilers reuse MSVC CRT, which implements these functions.
