### PR TITLE
Use fallback implementation for aligned alloc on WinCE

### DIFF
--- a/include/boost/align/aligned_alloc.hpp
+++ b/include/boost/align/aligned_alloc.hpp
@@ -19,7 +19,7 @@ http://boost.org/LICENSE_1_0.txt
 #include <AvailabilityMacros.h>
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(UNDER_CE)
 #include <boost/align/detail/aligned_alloc_msvc.hpp>
 #elif defined(__MINGW32__) && (__MSVCRT_VERSION__ >= 0x0700)
 #include <boost/align/detail/aligned_alloc_msvc.hpp>


### PR DESCRIPTION
MSVC doesn't provide aligned allocation functions for Windows CE, so don't attempt to use the ones for MSVC there.