### PR TITLE
aligned_allocator: cast away const-ness in construct

### DIFF
--- a/include/boost/align/aligned_allocator.hpp
+++ b/include/boost/align/aligned_allocator.hpp
@@ -96,24 +96,24 @@ public:
 #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     template<class U, class... Args>
     void construct(U* ptr, Args&&... args) {
-        ::new(static_cast<void*>(ptr)) U(std::forward<Args>(args)...);
+        ::new(const_cast<void*>(static_cast<const void*>(ptr))) U(std::forward<Args>(args)...);
     }
 #else
     template<class U, class V>
     void construct(U* ptr, V&& value) {
-        ::new(static_cast<void*>(ptr)) U(std::forward<V>(value));
+        ::new(const_cast<void*>(static_cast<const void*>(ptr))) U(std::forward<V>(value));
     }
 #endif
 #else
     template<class U, class V>
     void construct(U* ptr, const V& value) {
-        ::new(static_cast<void*>(ptr)) U(value);
+        ::new(const_cast<void*>(static_cast<const void*>(ptr))) U(value);
     }
 #endif
 
     template<class U>
     void construct(U* ptr) {
-        ::new(static_cast<void*>(ptr)) U();
+        ::new(const_cast<void*>(static_cast<const void*>(ptr))) U();
     }
 
     template<class U>


### PR DESCRIPTION
clang compile fix: adding entries into a std::map via operator[] calls
construct() on a const pointer.

----

```
./external_libraries/boost/boost/align/aligned_allocator.hpp:99:33: error: static_cast from 'const nova::symbol *' to 'void *' is not allowed
        ::new(const_cast<void*>(static_cast<void*>(ptr))) U(std::forward<Args>(args)...);
                                ^~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-7.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:1647:18: note: in instantiation of function template specialization 'boost::alignment::aligned_allocator<std::__1::__tree_node<std::__1::__value_type<nova::symbol, int>, void *>, 64>::construct<const nova::symbol, const nova::symbol &>' requested here
            {__a.construct(__p, _VSTD::forward<_Args>(__args)...);}
                 ^
/Applications/Xcode-7.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:1493:14: note: in instantiation of function template specialization 'std::__1::allocator_traits<boost::alignment::aligned_allocator<std::__1::__tree_node<std::__1::__value_type<nova::symbol, int>, void *>, 64> >::__construct<const nova::symbol, const nova::symbol &>' requested here
            {__construct(__has_construct<allocator_type, _Tp*, _Args...>(),
             ^
/Applications/Xcode-7.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:1522:20: note: in instantiation of function template specialization 'std::__1::allocator_traits<boost::alignment::aligned_allocator<std::__1::__tree_node<std::__1::__value_type<nova::symbol, int>, void *>, 64> >::construct<const nova::symbol, const nova::symbol &>' requested here
    __node_traits::construct(__na, _VSTD::addressof(__h->__value_.__cc.first), __k);
                   ^
/Applications/Xcode-7.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:1538:29: note: in instantiation of member function 'std::__1::map<nova::symbol, int, std::__1::less<nova::symbol>, boost::alignment::aligned_allocator<std::__1::pair<nova::symbol, int>, 64> >::__construct_node_with_key' requested here
        __node_holder __h = __construct_node_with_key(__k);
                            ^
../server/supernova/sc/sc_synthdef.cpp:235:22: note: in instantiation of member function 'std::__1::map<nova::symbol, int, std::__1::less<nova::symbol>, boost::alignment::aligned_allocator<std::__1::pair<nova::symbol, int>, 64> >::operator[]' requested here
        parameter_map[data] = index;

```