### PR TITLE
align: add alloc/free implementation based on operator new

### DIFF
--- a/include/boost/align/aligned_alloc.hpp
+++ b/include/boost/align/aligned_alloc.hpp
@@ -20,6 +20,8 @@ Distributed under the Boost Software License, Version 1.0.
 
 #if defined(BOOST_ALIGN_USE_ALLOCATE)
 #include <boost/align/detail/aligned_alloc.hpp>
+#elif defined(BOOST_ALIGN_USE_NEW)
+#include <boost/align/detail/aligned_alloc_new.hpp>
 #elif defined(_MSC_VER) && !defined(UNDER_CE)
 #include <boost/align/detail/aligned_alloc_msvc.hpp>
 #elif defined(__MINGW32__) && (__MSVCRT_VERSION__ >= 0x0700)

--- a/include/boost/align/detail/aligned_alloc_new.hpp
+++ b/include/boost/align/detail/aligned_alloc_new.hpp
@@ -1,0 +1,63 @@
+/*
+Copyright 2014-2015 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+Copyright 2020 Tim Blechmann
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#ifndef BOOST_ALIGN_DETAIL_ALIGNED_ALLOC_NEW_HPP
+#define BOOST_ALIGN_DETAIL_ALIGNED_ALLOC_NEW_HPP
+
+#include <boost/align/detail/is_alignment.hpp>
+#include <boost/align/align.hpp>
+#include <boost/align/alignment_of.hpp>
+#include <boost/assert.hpp>
+#include <boost/cstdint.hpp>
+#include <cstdlib>
+
+namespace boost {
+namespace alignment {
+
+inline void*
+aligned_alloc(std::size_t alignment, std::size_t size) BOOST_NOEXCEPT
+{
+#if __cplusplus >= 201703L
+    return static_cast<void*>(operator new[](sizeof(boost::uint8_t) * size, (std::align_val_t)(alignment)));
+#else
+    BOOST_ASSERT(detail::is_alignment(alignment));
+    enum {
+        N = alignment_of<void*>::value
+    };
+    if (alignment < N) {
+        alignment = N;
+    }
+    std::size_t n = size + alignment - N;
+    void* p = operator new[](sizeof(boost::uint8_t) * (sizeof(void*) + n));
+    if (p) {
+        void* r = static_cast<char*>(p) + sizeof(void*);
+        (void)boost::alignment::align(alignment, size, r, n);
+        *(static_cast<void**>(r) - 1) = p;
+        p = r;
+    }
+    return p;
+#endif
+}
+
+inline void
+aligned_free(void* ptr) BOOST_NOEXCEPT
+{
+#if __cplusplus >= 201703L
+    delete[] static_cast<boost::uint8_t*>(ptr);
+#else
+    if (ptr) {
+        delete[] static_cast<boost::uint8_t*>(static_cast<void**>(ptr) - 1);
+    }
+#endif
+
+}
+
+} /* alignment */
+} /* boost */
+
+#endif


### PR DESCRIPTION
default and fallback implementation map `aligned_alloc` and
`aligned_free` to malloc/free and the platform equivalents.

however there are certain advantages when using the global
operator `new`/`delete`, e.g. for applications that provide
custom implementations of these operators. we therefore add a new
implementation based on the c++ operators. when c++17 is available
we directly map to alignment-aware operators, otherwise we use the
trick of re-aligning un-aligned memory