### PR TITLE
[CMake] Remove throw_exception from dependency list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,4 @@ target_link_libraries(boost_align INTERFACE
     Boost::assert
     Boost::config
     Boost::core
-    Boost::static_assert
-)
+    Boost::static_assert)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,4 +19,4 @@ target_link_libraries(boost_align INTERFACE
     Boost::config
     Boost::core
     Boost::static_assert
-    Boost::throw_exception)
+)


### PR DESCRIPTION
According to boostdep, boost align doesn't include any header from throw_exception