### PR TITLE
Header file cleanup for C++20 header-units

### DIFF
--- a/include/boost/align/detail/align_down.hpp
+++ b/include/boost/align/detail/align_down.hpp
@@ -8,6 +8,7 @@ Distributed under the Boost Software License, Version 1.0.
 #ifndef BOOST_ALIGN_DETAIL_ALIGN_DOWN_HPP
 #define BOOST_ALIGN_DETAIL_ALIGN_DOWN_HPP
 
+#include <cstddef>
 #include <boost/align/detail/is_alignment.hpp>
 #include <boost/assert.hpp>
 


### PR DESCRIPTION
C++20 adds 'header units' as a stepping-stone to modules.  Header
units are regular header-files that have a 'self-contained' property
-- they do not require previously-included headers to provide typedefs
and what not.

This addresses a problem discovered when using clang modules (as a
proxy for C++20 header-units).

Some headers do not #include all the headers they need, relying on
their includer already having done that.  That breaks the above
mentioned encapuslation requirement.  Fixed by including the missing
headers.