### PR TITLE
Don't use FTMs to determine implementation choice.

### DIFF
--- a/include/boost/align/aligned_alloc.hpp
+++ b/include/boost/align/aligned_alloc.hpp
@@ -38,7 +38,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/align/detail/aligned_alloc_posix.hpp>
 #elif defined(sun) || defined(__sun)
 #include <boost/align/detail/aligned_alloc_sunos.hpp>
-#elif (_POSIX_C_SOURCE >= 200112L) || (_XOPEN_SOURCE >= 600)
+#elif defined(_POSIX_VERSION)
 #include <boost/align/detail/aligned_alloc_posix.hpp>
 #else
 #include <boost/align/detail/aligned_alloc.hpp>


### PR DESCRIPTION
Feature test macros should be defined before including system headers, and that's their only role. Using them later on to choose which implementation to use leads to issues with differing usage of FTMs across code bases.

qBittorrent, via libtorrent-rasterbar, via Boost ASIO, uses the align module, and was crashing on musl libc due to mismatched implementations: the alloc impl from aligned_alloc.h and the free impl from aligned_alloc_posix.h.

A more resilient way of checking for a POSIX system is with the _POSIX_VERSION macro, defined by <unistd.h>, which is included in this file. Ideally, however, this choice could somehow come from the Boost <config.h> header.