### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -50,7 +50,6 @@ install:
   - git submodule init libs/assert
   - git submodule init libs/config
   - git submodule init libs/core
-  - git submodule init libs/static_assert
   - git submodule init libs/throw_exception
   - git submodule init libs/headers
   - git submodule init tools/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
           git submodule init libs/assert
           git submodule init libs/config
           git submodule init libs/core
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/headers
           git submodule init tools/build
@@ -204,7 +203,6 @@ jobs:
           git submodule init libs/assert
           git submodule init libs/config
           git submodule init libs/core
-          git submodule init libs/static_assert
           git submodule init libs/throw_exception
           git submodule init libs/headers
           git submodule init tools/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -278,7 +278,6 @@ install:
   - git submodule init libs/assert
   - git submodule init libs/config
   - git submodule init libs/core
-  - git submodule init libs/static_assert
   - git submodule init libs/headers
   - git submodule init tools/build
   - git submodule init tools/boost_install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,4 @@ target_link_libraries(boost_align INTERFACE
     Boost::assert
     Boost::config
     Boost::core
-    Boost::static_assert
 )

--- a/build.jam
+++ b/build.jam
@@ -9,7 +9,7 @@ constant boost_dependencies :
     /boost/assert//boost_assert
     /boost/config//boost_config
     /boost/core//boost_core
-    /boost/static_assert//boost_static_assert ;
+    ;
 
 project /boost/align
     ;


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.